### PR TITLE
Update person

### DIFF
--- a/src/main/java/org/launchcode/familytree/controllers/PersonController.java
+++ b/src/main/java/org/launchcode/familytree/controllers/PersonController.java
@@ -11,8 +11,12 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Optional;
 
 @Controller
@@ -47,14 +51,15 @@ public class PersonController {
         return "redirect:";
     }
 
-    @GetMapping("update/{personId}")
-    public String renderUpdatePersonForm(Model model, @PathVariable int personId){
+    @GetMapping("update/{id}")
+    public String renderUpdatePersonForm(Model model, @PathVariable int id, HttpServletRequest request){
         model.addAttribute("title", "Update Person");
+        model.addAttribute("actionUrl", request.getRequestURI());
         model.addAttribute("persons", personRepository.findAll());
         model.addAttribute("genders", Gender.values());
-        Optional<Person> currentPerson = personRepository.findById(personId);
+        Optional<Person> currentPerson = personRepository.findById(id);
         if (currentPerson.isEmpty()) {
-            model.addAttribute("title", "Update Person");
+            model.addAttribute("title", "Invalid Person");
         } else {
             Person person = currentPerson.get();
             model.addAttribute("person", person);
@@ -62,17 +67,39 @@ public class PersonController {
         return "person/update";
     }
 
-    @PostMapping("/update/{personId}")
-    public String updatePerson(@PathVariable("personId") int personId, @Valid Person person, BindingResult result, Model model){
-        if (result.hasErrors()){
-            return "person/add";
+    @PostMapping(value = "update/{id}")
+    public String processUpdatePersonForm(@Valid @ModelAttribute Person person, RedirectAttributes model, Errors errors,
+                                          @RequestParam(name = "id") String id, @RequestParam(name = "firstName", required = false) String firstName,
+                                          @RequestParam(name = "middleName", required = false) String middleName, @RequestParam(name = "lastName", required = false) String lastName,
+                                          @RequestParam(name = "gender", required = false) Gender gender, @RequestParam(name = "bio", required = false) String bio,
+                                          @RequestParam(name = "graduation", required = false) String graduation, @RequestParam(name = "unionDate", required = false) String unionDate,
+                                          @RequestParam(name = "deathDate", required = false) String deathDate, @RequestParam(name = "parentId", required = false) String parentId,
+                                          @RequestParam(name = "parentIdTwo", required = false) String parentIdTwo, @RequestParam(name = "spouseId", required = false) String spouseId){
+        if (errors.hasErrors()) {
+            return "person/update";
         }
 
-        Optional<Person> optPerson = personRepository.findById(personId);
+        int i = Integer.parseInt(id);
+        int parId = Integer.parseInt(parentId);
+        int parIdTwo = Integer.parseInt(parentIdTwo);
+        int spId = Integer.parseInt(spouseId);
+//        Date grad = new SimpleDateFormat("MM/dd/yyyy").parse(graduation);
+        Optional<Person> optPerson = personRepository.findById(i);
         Person currentPerson = optPerson.get();
-        model.addAttribute("person", currentPerson);
+        model.addAttribute(currentPerson);
+        currentPerson.setFirstName(firstName);
+        currentPerson.setMiddleName(middleName);
+        currentPerson.setLastName(lastName);
+        currentPerson.setGender(gender);
+        currentPerson.setParentId(parId);
+        currentPerson.setParentIdTwo(parIdTwo);
+        currentPerson.setSpouseId(spId);
+//        currentPerson.setGraduation(graduation);
+//        currentPerson.setUnionDate(unionDate);
+//        currentPerson.setDeathDate(deathDate);
+        currentPerson.setBio(bio);
         personRepository.save(currentPerson);
-        return "redirect:";
+        return "redirect:/person/view/" + currentPerson.getId();
     }
 
 //    @GetMapping("/update")

--- a/src/main/java/org/launchcode/familytree/controllers/PersonController.java
+++ b/src/main/java/org/launchcode/familytree/controllers/PersonController.java
@@ -4,10 +4,13 @@ import org.launchcode.familytree.data.PersonRepository;
 import org.launchcode.familytree.models.Gender;
 import org.launchcode.familytree.models.Person;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.ModelAndView;
 
 import javax.validation.Valid;
 import java.util.Optional;
@@ -59,20 +62,41 @@ public class PersonController {
         return "person/update";
     }
 
-    @PostMapping("update")
-    public String updatePerson(@ModelAttribute Person person, @RequestParam String personId) {
-        int id = Integer.parseInt(personId);
-        Optional<Person> optPerson = personRepository.findById(id);
-        Person aPerson;
-        if (optPerson.isEmpty()) {
-            return "person/update";
-        } else {
-            aPerson = optPerson.get();
+    @PostMapping("/update/{personId}")
+    public String updatePerson(@PathVariable("personId") int personId, @Valid Person person, BindingResult result, Model model){
+        if (result.hasErrors()){
+            return "person/add";
         }
-        personRepository.save(aPerson);
-//        personRepository.save(person);
-        return "redirect:/person";
+
+        Optional<Person> optPerson = personRepository.findById(personId);
+        Person currentPerson = optPerson.get();
+        model.addAttribute("person", currentPerson);
+        personRepository.save(currentPerson);
+        return "redirect:";
     }
+
+//    @GetMapping("/update")
+//    public ModelAndView updateProfileView(@RequestParam Integer personId){
+//        ModelAndView mav = new ModelAndView("update");
+//        if(personRepository.findById(personId).isPresent()){
+//            mav.addObject(personRepository.findById(personId).get());
+//        }
+//        return mav;
+//    }
+
+//    @PutMapping("/{personId}")
+//    public String updatePerson(@ModelAttribute Person person, @PathVariable("personId") int personId) {
+//        Optional<Person> optPerson = personRepository.findById(personId);
+//        Person aPerson;
+//        if (optPerson.isEmpty()) {
+//            return "person/update";
+//        } else {
+//            aPerson = optPerson.get();
+//            aPerson.setFirstName();
+//        }
+////        personRepository.save(person);
+//        return "redirect:";
+//    }
 
     @GetMapping("view/{personId}")
     public String displayPerson(Model model, @PathVariable Integer personId) {

--- a/src/main/java/org/launchcode/familytree/controllers/PersonController.java
+++ b/src/main/java/org/launchcode/familytree/controllers/PersonController.java
@@ -44,8 +44,38 @@ public class PersonController {
         return "redirect:";
     }
 
+    @GetMapping("update/{personId}")
+    public String renderUpdatePersonForm(Model model, @PathVariable int personId){
+        model.addAttribute("title", "Update Person");
+        model.addAttribute("persons", personRepository.findAll());
+        model.addAttribute("genders", Gender.values());
+        Optional<Person> currentPerson = personRepository.findById(personId);
+        if (currentPerson.isEmpty()) {
+            model.addAttribute("title", "Update Person");
+        } else {
+            Person person = currentPerson.get();
+            model.addAttribute("person", person);
+        }
+        return "person/update";
+    }
+
+    @PostMapping("update")
+    public String updatePerson(@ModelAttribute Person person, @RequestParam String personId) {
+        int id = Integer.parseInt(personId);
+        Optional<Person> optPerson = personRepository.findById(id);
+        Person aPerson;
+        if (optPerson.isEmpty()) {
+            return "person/update";
+        } else {
+            aPerson = optPerson.get();
+        }
+        personRepository.save(aPerson);
+//        personRepository.save(person);
+        return "redirect:/person";
+    }
+
     @GetMapping("view/{personId}")
-    public String displayPerson(Model model, @PathVariable int personId) {
+    public String displayPerson(Model model, @PathVariable Integer personId) {
         model.addAttribute("title", "View Person");
 
         Optional<Person> optPerson = personRepository.findById(personId);

--- a/src/main/java/org/launchcode/familytree/controllers/PersonController.java
+++ b/src/main/java/org/launchcode/familytree/controllers/PersonController.java
@@ -118,7 +118,7 @@ public class PersonController {
         if (optParentTwo.isEmpty()) {
             model.addAttribute("title", "View Person");
         } else {
-            Person parentTwo = optParent.get();
+            Person parentTwo = optParentTwo.get();
             model.addAttribute("parentTwo", parentTwo);
         }
 
@@ -126,7 +126,7 @@ public class PersonController {
         if (optSpouse.isEmpty()) {
             model.addAttribute("title", "View Person");
         } else {
-            Person spouse = optParent.get();
+            Person spouse = optSpouse.get();
             model.addAttribute("spouse", spouse);
         }
         return "person/view";

--- a/src/main/java/org/launchcode/familytree/models/Gender.java
+++ b/src/main/java/org/launchcode/familytree/models/Gender.java
@@ -4,7 +4,6 @@ public enum Gender {
     PREFERNOTTOSAY ("Prefer not to say"),
     MAN ("Man"),
     WOMAN ("Woman"),
-    TRANSGENDER ("Transgender"),
     NONBINARY ("Non-binary/non-conforming");
 
     private final String displayName;

--- a/src/main/java/org/launchcode/familytree/models/Person.java
+++ b/src/main/java/org/launchcode/familytree/models/Person.java
@@ -9,8 +9,13 @@ import javax.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Date;
+
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.format.annotation.DateTimeFormat;
 
+@DynamicInsert
+@DynamicUpdate
 @Entity
 public class Person {
     @Id

--- a/src/main/java/org/launchcode/familytree/models/Person.java
+++ b/src/main/java/org/launchcode/familytree/models/Person.java
@@ -14,8 +14,6 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.format.annotation.DateTimeFormat;
 
-@DynamicInsert
-@DynamicUpdate
 @Entity
 public class Person {
     @Id

--- a/src/main/resources/templates/person/add.html
+++ b/src/main/resources/templates/person/add.html
@@ -53,7 +53,7 @@
     <div>
         <div class="form-group mb-3 px-5">
             <p class="mb-3">Select your family members</p>
-            <label class="form-label mx-2">Parent </label>
+            <label class="form-label mx-2">Child </label>
             <select th:field="${person.parentId}">
                 <option class="dropdown-item" value="0">Please Select</option>
                 <option class="dropdown-item" name="parentId" th:each="person : ${persons}" th:value="${person.id}" th:text="${person.firstName} + ' ' + ${person.lastName}"></option>
@@ -61,7 +61,7 @@
             <p class="fs-6 text-danger" th:errors="${person.parentId}"></p>
         </div>
         <div class="form-group mb-3 px-5">
-            <label class="form-label mx-2">Parent </label>
+            <label class="form-label mx-2">Child </label>
             <select th:field="${person.parentIdTwo}">
                 <option class="dropdown-item" value="0">Please Select</option>
                 <option class="dropdown-item" name="parentIdTwo" th:each="person : ${persons}" th:value="${person.id}" th:text="${person.firstName} + ' ' + ${person.lastName}"></option>

--- a/src/main/resources/templates/person/update.html
+++ b/src/main/resources/templates/person/update.html
@@ -8,8 +8,7 @@
     Update Your Family Tree
 </h3>
 <p class="mb-3">Fill out everything that applies to your person and leave the rest blank.</p>
-<form action="person/update" th:action="@{/person/update}" th:object="${person}" method="post">
-    <input type="hidden" name="personId" id="personId" th:value="${person.id}">
+<form action="#" th:action="@{/person/update/{personId}(personId=${person.id})}" th:object="${person}" method="post">
     <div class="form-group mb-3 px-5">
         <label class="form-label mx-2">First Name
             <input th:field="${person.firstName}" class="form-control">
@@ -87,6 +86,7 @@
     <div class="form-group px-5">
         <input type="submit" value="UPDATE PERSON" class="btn btn-secondary">
     </div>
+    <input type="hidden" name="personId" id="personId" th:value="${person.id}">
 </form>
 <footer th:replace = "fragments :: footer"></footer>
 </body>

--- a/src/main/resources/templates/person/update.html
+++ b/src/main/resources/templates/person/update.html
@@ -8,7 +8,8 @@
     Update Your Family Tree
 </h3>
 <p class="mb-3">Fill out everything that applies to your person and leave the rest blank.</p>
-<form action="#" th:action="@{/person/update/{personId}(personId=${person.id})}" th:object="${person}" method="post">
+<form method="post" th:action="${actionUrl}" th:object="${person}">
+    <input type="hidden" th:field="*{id}" />
     <div class="form-group mb-3 px-5">
         <label class="form-label mx-2">First Name
             <input th:field="${person.firstName}" class="form-control">
@@ -53,7 +54,7 @@
     <div>
         <div class="form-group mb-3 px-5">
             <p class="mb-3">Select your family members</p>
-            <label class="form-label mx-2">Parent </label>
+            <label class="form-label mx-2">Child </label>
             <select th:field="${person.parentId}">
                 <option class="dropdown-item" value="0">Please Select</option>
                 <option class="dropdown-item" name="parentId" th:each="person : ${persons}" th:value="${person.id}" th:text="${person.firstName} + ' ' + ${person.lastName}"></option>
@@ -61,7 +62,7 @@
             <p class="fs-6 text-danger" th:errors="${person.parentId}"></p>
         </div>
         <div class="form-group mb-3 px-5">
-            <label class="form-label mx-2">Parent </label>
+            <label class="form-label mx-2">Child </label>
             <select th:field="${person.parentIdTwo}">
                 <option class="dropdown-item" value="0">Please Select</option>
                 <option class="dropdown-item" name="parentIdTwo" th:each="person : ${persons}" th:value="${person.id}" th:text="${person.firstName} + ' ' + ${person.lastName}"></option>
@@ -86,7 +87,7 @@
     <div class="form-group px-5">
         <input type="submit" value="UPDATE PERSON" class="btn btn-secondary">
     </div>
-    <input type="hidden" name="personId" id="personId" th:value="${person.id}">
+<!--    <input type="hidden" name="personId" id="personId" th:value="${person.id}">-->
 </form>
 <footer th:replace = "fragments :: footer"></footer>
 </body>

--- a/src/main/resources/templates/person/update.html
+++ b/src/main/resources/templates/person/update.html
@@ -5,13 +5,14 @@
 <body class="container">
 <nav th:replace = "fragments :: navbar"></nav>
 <h3 class="pt-5">
-    Add a Person to Your Family Tree
+    Update Your Family Tree
 </h3>
 <p class="mb-3">Fill out everything that applies to your person and leave the rest blank.</p>
-<form method="post" action="/person/add">
+<form action="person/update" th:action="@{/person/update}" th:object="${person}" method="post">
+    <input type="hidden" name="personId" id="personId" th:value="${person.id}">
     <div class="form-group mb-3 px-5">
         <label class="form-label mx-2">First Name
-            <input th:field="${person.firstName}" class="form-control" required>
+            <input th:field="${person.firstName}" class="form-control">
         </label>
         <p class="fs-6 text-danger" th:errors="${person.firstName}"></p>
         <label class="form-label mx-2">Middle Name
@@ -84,7 +85,7 @@
         </label>
     </div>
     <div class="form-group px-5">
-        <input type="submit" value="ADD PERSON" class="btn btn-secondary">
+        <input type="submit" value="UPDATE PERSON" class="btn btn-secondary">
     </div>
 </form>
 <footer th:replace = "fragments :: footer"></footer>

--- a/src/main/resources/templates/person/view.html
+++ b/src/main/resources/templates/person/view.html
@@ -43,14 +43,13 @@
                         Family Members
                     </div>
                     <ul class="list-group list-group-flush">
-                        <li class="list-group-item" th:if="${person.parentId}" th:text="'Parent: ' + ${parent.firstName} + ' ' + ${parent.middleName} + ' ' + ${parent.lastName}"></li>
-                        <li class="list-group-item" th:if="${person.parentIdTwo}" th:text="'Parent: ' + ${parentTwo.firstName} + ' ' + ${parentTwo.middleName} + ' ' + ${parentTwo.lastName}"></li>
+                        <li class="list-group-item" th:if="${person.parentId}" th:text="'Child: ' + ${parent.firstName} + ' ' + ${parent.middleName} + ' ' + ${parent.lastName}"></li>
+                        <li class="list-group-item" th:if="${person.parentIdTwo}" th:text="'Child: ' + ${parentTwo.firstName} + ' ' + ${parentTwo.middleName} + ' ' + ${parentTwo.lastName}"></li>
                         <li class="list-group-item" th:if="${person.spouseId}" th:text="'Partner: ' + ${spouse.firstName} + ' ' + ${spouse.middleName} + ' ' + ${spouse.lastName}"></li>
                     </ul>
                 </div>
                 <div class="d-flex justify-content-start py-3 gap-3">
                     <a th:href="@{'/person/update/' + ${person.id}}" role="button" class="btn btn-secondary btn">UPDATE</a>
-<!--                    <button class="btn btn-secondary btn" onclick="window.location.href='th:href="@{'/person/view/' + ${person.id}}"'"> UPDATE</button>-->
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/person/view.html
+++ b/src/main/resources/templates/person/view.html
@@ -18,7 +18,6 @@
                         <h2 class="card-title mb-3" th:text="${person.firstName} + ' ' + ${person.middleName} + ' ' +  ${person.lastName}">
                             Default Title
                         </h2>
-                        <a href="#" class="btn btn-primary">Uploads</a>
                     </div>
                 </div>
             </div>
@@ -50,7 +49,8 @@
                     </ul>
                 </div>
                 <div class="d-flex justify-content-start py-3 gap-3">
-                    <button class="btn btn-primary btn">Update</button>
+                    <a th:href="@{'/person/update/' + ${person.id}}" role="button" class="btn btn-secondary btn">UPDATE</a>
+<!--                    <button class="btn btn-secondary btn" onclick="window.location.href='th:href="@{'/person/view/' + ${person.id}}"'"> UPDATE</button>-->
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/tree/index.html
+++ b/src/main/resources/templates/tree/index.html
@@ -6,10 +6,8 @@
   <body class="container">
     <nav th:replace="fragments :: navbar"></nav>
 
-    <br>
-    <br>
-    <div id="treeArea"></div>
-    <br>
+
+    <div id="treeArea" class="mb-3 mt-5"></div>
 
     <div id="treeControlsArea">
       <button onclick="zoomIn()">Zoom In ➕</button>


### PR DESCRIPTION
**Update person**

- People can now be updated from a person's view or from person/update/id
- All fields can be updated except for dates (Currently working on this, but wanted to merge these changes nonetheless. Date fields are commented out right now, so everything should run properly.)

**Child not parent**

- Because of the way the tree is set up, we are now selecting a person's children rather than their parents in the add person form
- This is also reflected in the view

**Gender change**

- If you already have a person table, you will need to drop it before running this because of enum gender options changing

**Formatting updates**

- There are also minor formatting updates to the colors of buttons (secondary) and spacing on the family tree